### PR TITLE
Add show_last_separator option

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ Show bufnr in tabline for each buffer (default = false)
 
 Show only filename instead of shortened full path (default = false)
 
+### tabline_show_last_separator
+
+Show separator after the last buffer or tab (default = false)
+
 # Lualine tabline support
 
 [`nvim-lualine/lualine.nvim`](https://github.com/nvim-lualine/lualine.nvim) now has buffers and tabs as components.

--- a/lua/tabline.lua
+++ b/lua/tabline.lua
@@ -580,7 +580,7 @@ function M.tabline_buffers(opt)
     if i == 1 then
       buffer.first = true
     end
-    if i == #buffers then
+    if i == #buffers and not M.options.show_last_separator then
       buffer.last = true
     end
     if buffer.bufnr == vim.fn.bufnr() then
@@ -642,7 +642,7 @@ function M.tabline_tabs(opt)
     if i == 1 then
       tab.first = true
     end
-    if i == #tabs then
+    if i == #tabs and not M.options.show_last_separator then
       tab.last = true
     end
     if tab.tabnr == vim.fn.tabpagenr() then
@@ -735,6 +735,7 @@ function M.setup(opts)
     let g:tabline_show_devicons = get(g:, "tabline_show_devicons", v:true)
     let g:tabline_show_bufnr = get(g:, "tabline_show_bufnr", v:false)
     let g:tabline_show_filename_only = get(g:, "tabline_show_filename_only", v:false)
+    let g:tabline_show_last_separator = get(g:, "tabline_show_last_separator", v:false)
     let g:tabline_show_tabs_always = get(g:, "tabline_show_tabs_always", v:false)
   ]])
 
@@ -809,6 +810,12 @@ function M.setup(opts)
     M.options.show_filename_only = opts.options.show_filename_only
   else
     M.options.show_filename_only = vim.g.tabline_show_filename_only
+  end
+
+  if opts.options.show_last_separator then
+    M.options.show_last_separator = opts.options.show_last_separator
+  else
+    M.options.show_last_separator = vim.g.tabline_show_last_separator
   end
 
   vim.cmd([[


### PR DESCRIPTION
I really like the way tabline looks with a separator after the last buffer/tab (even when not actively selected) and think it would be great if there was an option to enable that in the settings.