### PR TITLE
Add option for italicised modified filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ use {
         show_bufnr = false, -- this appends [bufnr] to buffer section,
         show_filename_only = false, -- shows base filename only instead of relative path in filename
         modified_icon = "+ ", -- change the default modified icon
+        modified_italic = false, -- set to true by default; this determines whether the filename turns italic if modified
       }
     }
     vim.cmd[[

--- a/lua/tabline.lua
+++ b/lua/tabline.lua
@@ -629,15 +629,15 @@ function M.tabline_buffers(opt)
 end
 
 function Buffer:hl()
-  if self.current and self.modified then
+  if self.current and self.modified and M.options.modified_italic then
     return "%#tabline_a_normal_italic#"
   elseif self.current then
     return "%#tabline_a_normal#"
-  elseif self.visible and self.modified then
+  elseif self.visible and self.modified and M.options.modified_italic then
     return "%#tabline_b_normal_bold_italic#"
   elseif self.visible then
     return "%#tabline_b_normal_bold#"
-  elseif self.modified then
+  elseif self.modified and M.options.modified_italic then
     return "%#tabline_b_normal_italic#"
   else
     return "%#tabline_b_normal#"
@@ -852,6 +852,10 @@ function M.setup(opts)
     M.options.modified_icon = opts.options.modified_icon
   else
     M.options.modified_icon = vim.g.tabline_modified_icon
+  end
+
+  if opts.options.modified_italic then
+    M.options.modified_italic = opts.options.modified_italic
   end
 
 


### PR DESCRIPTION
The name of a modified file in the tab line is italicised. After the addition of #27, some substitute character for `modified_icon`, like `[+]`, will instead look like *`[+]`*, which is arguably not as pleasing to look at (unlike the original character, ``, which is not affected by italicisation).

This PR adds a new `modified_italic` option changeable through `setup`:

```diff
require('tabline').setup {
    enable = true,
    options = {
        modified_icon = "[+] ",
+       modified_italic = false,
    },
}
```