### PR TITLE
Make show_tabs_always option behave how it should

### DIFF
--- a/lua/tabline.lua
+++ b/lua/tabline.lua
@@ -951,7 +951,11 @@ function M.setup(opts)
 
   if opts.enable then
     vim.o.tabline = "%!v:lua.tabline_buffers_tabs()"
-    vim.o.showtabline = 2
+    if M.options.show_tabs_always then
+      vim.o.showtabline = 2
+    else
+      vim.o.showtabline = 1
+    end
   end
 end
 


### PR DESCRIPTION
As of now, the show_tabs_always option does not influence the appearance of tabline at all, as everything is shown regardless. Maybe this was accidentally changed at some point, idk. This pull request aims to give the show_tabs_always option meaning.