### PR TITLE
Fix the `allowed_buffers` table

### DIFF
--- a/lua/tabline.lua
+++ b/lua/tabline.lua
@@ -491,10 +491,10 @@ end
 function M._bind_buffers(args)
   local filelist = {}
   if #args == 0 then
-    filelist[#filelist + 1] = vim.fn.expand("%:p:~")
+    filelist[vim.fn.expand("%:p:~")] = true
   else
     for _, buffer_name in pairs(args) do
-      filelist[#filelist + 1] = vim.fn.fnamemodify(vim.fn.expand(buffer_name), ":p:~")
+      filelist[vim.fn.fnamemodify(vim.fn.expand(buffer_name), ":p:~")] = true
     end
   end
   local data = vim.fn.json_decode(vim.g.tabline_tab_data)


### PR DESCRIPTION
Originally the `allowed_buffers` table of current tab, if created with `:TablineTabNew`, is a set with filepath as its keys and `true` as values, but if created with `:TablineBuffersBind`, it would be a list with filepath as its values.
And the `contains` function tests for the list-like behavior, so `:TablineTabNew` has some weird behavior when called with multiple files.

This PR changes `M._bind_buffers()` and removes `contains()` to ensure that `allowed_buffers` is always a set-like structure and is tested with indexes.

I'd also like to ask if it's better to store bufnr (which could be get with `bufname()`) instead of filepath in `allowed_buffers`.

PS: Thank you for creating this plugin. It's embarrassing that I didn't know the "tab" part is so useful until today...