### PR TITLE
Splitting show_tabs_always into show_tabline_buffers and show_tabline_tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,14 @@ use {
         section_separators = {'', ''},
         component_separators = {'', ''},
         max_bufferline_percent = 66, -- set to nil by default, and it uses vim.o.columns * 2/3
-        show_tabs_always = false, -- this shows tabs only when there are more than one tab or if the first tab is named
         show_devicons = true, -- this shows devicons in buffer section
         show_bufnr = false, -- this appends [bufnr] to buffer section,
         show_filename_only = false, -- shows base filename only instead of relative path in filename
         modified_icon = "+ ", -- change the default modified icon
         modified_italic = false, -- set to true by default; this determines whether the filename turns italic if modified
         show_tabs_only = false, -- this shows only tabs instead of tabs + buffers
+        show_tabline_buffers = 2, -- this shows buffer names (the left section of the tabline) always, when there is more than one buffer, or never
+        show_tabline_tabs = 1, -- this shows tab names (the right section of the tabline) always, when there is more than one or a named tab, or never
       }
     }
     vim.cmd[[
@@ -101,6 +102,14 @@ Show separator after the last buffer or tab (default = false)
 ### tabline_show_tabs_only
 
 Show only tabs instead of tabs + buffers (default = false)
+
+### tabline_show_tabline_buffers
+
+Shows the buffer names (the left section of the tabline) always (2), when there is more than one buffer (1), or never (0) (default = 2)
+
+### tabline_show_tabline_tabs
+
+Shows the tab names (the right section of the tabline) always (2), when there is more than one or a named tab (1), or never (0) (default = 1)
 
 # Lualine tabline support
 

--- a/lua/tabline.lua
+++ b/lua/tabline.lua
@@ -972,12 +972,17 @@ function M.setup(opts)
   -- to_delete: the count of buffers to be deleted after this call
   function _G.update_tabline_visibility(to_delete)
     local tab_count = vim.fn.tabpagenr('$')
-    local buf_count = -to_delete
-    for b = 1, vim.fn.bufnr('$') do
-      -- this should be a function (same tests repeated for 4 times...)
-      if vim.fn.buflisted(b) ~= 0 and vim.fn.getbufvar(b, "&buftype") ~= "quickfix" then
-        buf_count = buf_count + 1
+    local buf_count
+    if M.options.show_tabs_only == false then
+      buf_count = -to_delete
+      for b = 1, vim.fn.bufnr('$') do
+        -- this should be a function (same tests repeated for 4 times...)
+        if vim.fn.buflisted(b) ~= 0 and vim.fn.getbufvar(b, "&buftype") ~= "quickfix" then
+          buf_count = buf_count + 1
+        end
       end
+    else
+      buf_count = tab_count
     end
 
     local function is_shown(opt, count)


### PR DESCRIPTION
This PR removes `show_tabs_always` (which was not even properly documented btw) and adds two options to take its place:
`show_tabline_buffers` and `show_tabline_tabs`.
How these exactly work is documented in the README.
When there is nothing to show, the tabline will just vanish.
These options also properly function in combination with `show_tabs_only`.
This aims to make the tabline more configurable for everybody, "tab" and "buffer" users alike.

Also huge thanks to @s-cerevisiae for the enormous help fixing visibility updating issues.