### PR TITLE
Add user defined buffer number style.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ use {
         show_tabs_always = false, -- this shows tabs only when there are more than one tab or if the first tab is named
         show_devicons = true, -- this shows devicons in buffer section
         show_bufnr = false, -- this appends [bufnr] to buffer section,
+        bufnr_style = { '⁰', '¹', '²', '³', '⁴', '⁵', '⁶', '⁷', '⁸', '⁹' }, -- this change the [bufnr] style
+        bufnr_direction = true, -- set true to put buffer number at title's left
         show_filename_only = false, -- shows base filename only instead of relative path in filename
         modified_icon = "+ ", -- change the default modified icon
         modified_italic = false, -- set to true by default; this determines whether the filename turns italic if modified

--- a/lua/tabline.lua
+++ b/lua/tabline.lua
@@ -363,7 +363,12 @@ local function nrmap(nr, map)
   local ret = ''
   while ( tmp ~= 0 )
   do
-    ret = map[tmp%10+1] .. ret
+    local mapval = map[tmp%10+1]
+    if mapval then
+      ret = map[tmp%10+1] .. ret
+    else
+      ret = tmp%10 .. ret
+    end
     tmp = math.floor(tmp/10)
   end
   return ret

--- a/lua/tabline.lua
+++ b/lua/tabline.lua
@@ -358,6 +358,26 @@ function Buffer:name()
   return vim.fn.pathshorten(vim.fn.fnamemodify(self.file, ":p:."))
 end
 
+local function nrmap(nr, map)
+  local tmp = nr
+  local ret = ''
+  while ( tmp ~= 0 )
+  do
+    ret = map[tmp%10+1] .. ret
+    tmp = math.floor(tmp/10)
+  end
+  return ret
+end
+
+function Buffer:bufnr_render(bufnr)
+  local style = M.options.bufnr_style
+  if style then
+    return nrmap(bufnr, style)
+  else
+    return "[" .. bufnr .. "] "
+  end
+end
+
 function Buffer:render()
   local line = self:hl()
       .. "%"
@@ -368,13 +388,22 @@ function Buffer:render()
         .. " "
         .. self.icon
   end
-  line = line
-      .. " "
-      .. self.name
-      .. " "
-      .. self.modified_icon
   if M.options.show_bufnr then
-    line = line .. "[" .. self.bufnr .. "] "
+    if M.options.bufnr_direction then
+      line = line
+          .. " "
+          .. self:bufnr_render(self.bufnr)
+          .. self.name
+          .. " "
+          .. self.modified_icon
+    else
+      line = line
+          .. " "
+          .. self.name
+          .. " "
+          .. self.modified_icon
+          .. self:bufnr_render(self.bufnr)
+    end
   end
   line = line .. "%T" .. self:separator()
   return line
@@ -889,6 +918,18 @@ function M.setup(opts)
     M.options.show_bufnr = opts.options.show_bufnr
   else
     M.options.show_bufnr = vim.g.tabline_show_bufnr
+  end
+
+  if opts.options.bufnr_style ~= nil then
+    M.options.bufnr_style = opts.options.bufnr_style
+  else
+    M.options.bufnr_style = vim.g.tabline_bufnr_style
+  end
+
+  if opts.options.bufnr_direction ~= nil then
+    M.options.bufnr_direction = opts.options.bufnr_direction
+  else
+    M.options.bufnr_direction = vim.g.tabline_bufnr_direction
   end
 
   if opts.options.show_devicons ~= nil then


### PR DESCRIPTION
This PR add the options to change the style of buffer number to make it looks better.
`bufnr_style`: table, the mapping target.
For example, buffer number 21 will map to ²¹ using the configuration.
```
bufnr_style = { '⁰', '¹', '²', '³', '⁴', '⁵', '⁶', '⁷', '⁸', '⁹' }
```
`bufnr_direction`: boolen, set true to put buffer number to left.
